### PR TITLE
Fix Zero gravity & optimize entity ticks

### DIFF
--- a/Common/src/main/java/net/sonunte/hexkinetics/common/casting/actions/great_spells/OpAcceleration.kt
+++ b/Common/src/main/java/net/sonunte/hexkinetics/common/casting/actions/great_spells/OpAcceleration.kt
@@ -4,7 +4,6 @@ import at.petrak.hexcasting.api.misc.MediaConstants
 import at.petrak.hexcasting.api.spell.*
 import at.petrak.hexcasting.api.spell.casting.CastingContext
 import at.petrak.hexcasting.api.spell.iota.Iota
-import net.minecraft.server.level.ServerLevel
 import net.minecraft.util.Mth
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.phys.Vec3
@@ -45,30 +44,32 @@ object OpAcceleration : SpellAction {
 
 	private data class Spell(val target: Entity, val time: Double, val force: Vec3) : RenderedSpell {
 		override fun cast(ctx: CastingContext) {
-			if (entityFastTicks[target]!! > 0)
+			if (entityFastTicks.containsKey(target))
 				return   // don't change the already set propulsion
 			supertime = time.toInt() * 5 + 5
 			entityFastTicks[target] = supertime
 			entityWaitTicks[target] = 0
 			speed = force
-			tickAccelerate(target, force)
+			tickAccelerate(target, force, supertime)
 
 		}
 	}
 
 	@JvmStatic
-	fun tickDownAllEntities(world: ServerLevel) {
-		for (entity in world.allEntities) {
-			entityFastTicks.computeIfAbsent(entity) { 0 }
-			tickAccelerate(entity, speed)
+	fun tickAcceleratedEntities() {
+		for ((entity, ticks) in entityFastTicks) {
+			if (!entity.isRemoved) {
+				tickAccelerate(entity, speed, ticks)
+			} else {
+				entityFastTicks.remove(entity)
+				entityWaitTicks.remove(entity)
+			}
 		}
 	}
 
 	@JvmStatic
-	fun tickAccelerate(target: Entity, force: Vec3) {
-		val tick = entityFastTicks[target] ?: supertime
-
-		if (tick > 0) {
+	fun tickAccelerate(target: Entity, force: Vec3, ticks: Int) {
+		if (ticks > 0) {
 			val wait = entityWaitTicks[target] ?: 0
 
 			if (wait >= 0) {
@@ -79,16 +80,14 @@ object OpAcceleration : SpellAction {
 				}
 				entityWaitTicks[target] = wait + 1
 			}
-			entityFastTicks[target] = tick - 1
+			entityFastTicks[target] = ticks - 1
 
 			if (wait < 0 || wait > 5) {
 				entityWaitTicks[target] = 0
 			}
-		}
-		if (tick <= 0) {
-			if (tick < 0) {
-				entityFastTicks[target] = 0
-			}
+		} else {
+			entityFastTicks.remove(target)
+			entityWaitTicks.remove(target)
 		}
 	}
 

--- a/Common/src/main/java/net/sonunte/hexkinetics/common/casting/actions/great_spells/OpZeroG.kt
+++ b/Common/src/main/java/net/sonunte/hexkinetics/common/casting/actions/great_spells/OpZeroG.kt
@@ -46,12 +46,18 @@ object OpZeroG : SpellAction {
 	@JvmStatic
 	fun tickZeroGEntities() {
 		for ((entity, ticks) in entityTicks) {
-			val removalReason = entity.removalReason
-			if (removalReason == null) {
+			if (!entity.isRemoved) {
 				tickDownNoGravity(entity, ticks)
-			} else if (removalReason.shouldDestroy()) {
+			} else {
 				entityTicks.remove(entity)
 			}
+		}
+	}
+
+	@JvmStatic
+	fun unloadZeroGEntity(entity: Entity) {
+		if (entityTicks.remove(entity) != null) {
+			entity.isNoGravity = false;
 		}
 	}
 

--- a/Common/src/main/java/net/sonunte/hexkinetics/common/casting/actions/great_spells/OpZeroG.kt
+++ b/Common/src/main/java/net/sonunte/hexkinetics/common/casting/actions/great_spells/OpZeroG.kt
@@ -4,7 +4,6 @@ import at.petrak.hexcasting.api.misc.MediaConstants
 import at.petrak.hexcasting.api.spell.*
 import at.petrak.hexcasting.api.spell.casting.CastingContext
 import at.petrak.hexcasting.api.spell.iota.Iota
-import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.entity.Entity
 
 object OpZeroG : SpellAction {
@@ -34,28 +33,31 @@ object OpZeroG : SpellAction {
 
 	private data class Spell(val target: Entity, val time: Double) : RenderedSpell {
 		override fun cast(ctx: CastingContext) {
-			ticks = time.toInt() * 20
-			entityTicks[target] = ticks
-			target.isNoGravity = true
-			target.hurtMarked = true //Why!?
-			tickDownNoGravity(target)
-
+			if (!target.isNoGravity || entityTicks.containsKey(target)) {
+				ticks = time.toInt() * 20
+				entityTicks[target] = ticks
+				target.isNoGravity = true
+				target.hurtMarked = true //Why!?
+				tickDownNoGravity(target, ticks)
+			}
 		}
 	}
 
 	@JvmStatic
-	fun tickAllEntities(world: ServerLevel) {
-		for (entity in world.allEntities) {
-			entityTicks.computeIfAbsent(entity) { 0 }
-			tickDownNoGravity(entity)
+	fun tickZeroGEntities() {
+		for ((entity, ticks) in entityTicks) {
+			val removalReason = entity.removalReason
+			if (removalReason == null) {
+				tickDownNoGravity(entity, ticks)
+			} else if (removalReason.shouldDestroy()) {
+				entityTicks.remove(entity)
+			}
 		}
 	}
 
 	@JvmStatic
-	fun tickDownNoGravity(target: Entity) {
-		val tick = entityTicks[target] ?: ticks
-
-		if (tick > 0) {
+	fun tickDownNoGravity(target: Entity, ticks: Int) {
+		if (ticks > 0) {
 			target.resetFallDistance()
 			target.push(
 				target.deltaMovement.x * 0.1,
@@ -63,13 +65,9 @@ object OpZeroG : SpellAction {
 				target.deltaMovement.z * 0.1
 			)
 			target.hurtMarked = true
-			entityTicks[target] = tick - 1
-		}
-
-		if (tick <= 0) {
-			if (tick < 0) {
-				entityTicks[target] = 0
-			}
+			entityTicks[target] = ticks - 1
+		} else {
+			entityTicks.remove(target)
 			target.isNoGravity = false
 		}
 	}

--- a/Fabric/src/main/java/net/sonunte/hexkinetics/fabric/FabricYourModInitializer.kt
+++ b/Fabric/src/main/java/net/sonunte/hexkinetics/fabric/FabricYourModInitializer.kt
@@ -1,6 +1,7 @@
 package net.sonunte.hexkinetics.fabric
 
 import net.fabricmc.api.ModInitializer
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
 import net.minecraft.core.Registry
 import net.minecraft.resources.ResourceLocation
@@ -26,6 +27,10 @@ object FabricYourModInitializer : ModInitializer {
         ServerTickEvents.END_SERVER_TICK.register {
             OpZeroG.tickZeroGEntities()
             OpAcceleration.tickAcceleratedEntities()
+        }
+
+        ServerEntityEvents.ENTITY_UNLOAD.register { entity, world ->
+            OpZeroG.unloadZeroGEntity(entity)
         }
     }
 

--- a/Fabric/src/main/java/net/sonunte/hexkinetics/fabric/FabricYourModInitializer.kt
+++ b/Fabric/src/main/java/net/sonunte/hexkinetics/fabric/FabricYourModInitializer.kt
@@ -23,11 +23,9 @@ object FabricYourModInitializer : ModInitializer {
 
         Patterns.registerPatterns()
 
-        ServerTickEvents.END_SERVER_TICK.register { server ->
+        ServerTickEvents.END_SERVER_TICK.register {
             OpZeroG.tickZeroGEntities()
-            server.allLevels.forEach { dimension ->
-                OpAcceleration.tickDownAllEntities(dimension)
-            }
+            OpAcceleration.tickAcceleratedEntities()
         }
     }
 

--- a/Fabric/src/main/java/net/sonunte/hexkinetics/fabric/FabricYourModInitializer.kt
+++ b/Fabric/src/main/java/net/sonunte/hexkinetics/fabric/FabricYourModInitializer.kt
@@ -24,10 +24,10 @@ object FabricYourModInitializer : ModInitializer {
         Patterns.registerPatterns()
 
         ServerTickEvents.END_SERVER_TICK.register { server ->
-                server.allLevels.forEach { dimension ->
-                    OpZeroG.tickAllEntities(dimension)
-                    OpAcceleration.tickDownAllEntities(dimension)
-                }
+            OpZeroG.tickZeroGEntities()
+            server.allLevels.forEach { dimension ->
+                OpAcceleration.tickDownAllEntities(dimension)
+            }
         }
     }
 


### PR DESCRIPTION
This mod was breaking no-gravity armor stands on my server, so I made that ZeroG spell does nothing if entity already has no gravity. Also ZeroG and Accelerate spells now tick only entities that were modified by them, and entities are removed from maps when spell effect ends or entity dies/unloads, to prevent memory leaks.